### PR TITLE
Fix error: mis-spelled function name

### DIFF
--- a/include/caffe/loss_layers.hpp
+++ b/include/caffe/loss_layers.hpp
@@ -42,7 +42,7 @@ class AccuracyLayer : public Layer<Dtype> {
   // If there are two top blobs, then the second blob will contain
   // accuracies per class.
   virtual inline int MinTopBlobs() const { return 1; }
-  virtual inline int MaxTopBlos() const { return 2; }
+  virtual inline int MaxTopBlobs() const { return 2; }
 
  protected:
   /**


### PR DESCRIPTION
By being named incorrectly, this function was doing nothing.
Using the correct name will catch (uncommon) errors in net setup of Layers, i.e. extraneous top Blob's to AccuracyLayer.
